### PR TITLE
Fix import path error

### DIFF
--- a/python/third_party/open_model_zoo/tools/downloader/downloader.py
+++ b/python/third_party/open_model_zoo/tools/downloader/downloader.py
@@ -32,7 +32,7 @@ import types
 
 from pathlib import Path
 
-from . import common
+import common
 
 CHUNK_SIZE = 1 << 15 if sys.stdout.isatty() else 1 << 20
 


### PR DESCRIPTION
only downloader has wrong path.
it cause import error unlike converter.py or quantizer.py